### PR TITLE
Set Default Filter Value of 500 for Row Selection

### DIFF
--- a/src/z2ui5_cl_se16_01.clas.abap
+++ b/src/z2ui5_cl_se16_01.clas.abap
@@ -122,6 +122,7 @@
      mo_ui_ranges = NEW z2ui5_cl_ui_build_ranges( ).
      mo_ui_ranges->mo_sql = NEW #( ).
      mo_ui_ranges->mo_sql->ms_sql-tabname = `USR01`.
+     mo_ui_ranges->mo_sql->ms_sql-count   = `500`.
 
      DATA lr_table TYPE REF TO data.
      CREATE DATA lr_table TYPE TABLE OF spfli.

--- a/src/z2ui5_cl_util_sql.clas.abap
+++ b/src/z2ui5_cl_util_sql.clas.abap
@@ -42,7 +42,7 @@ CLASS z2ui5_cl_util_sql IMPLEMENTATION.
      *
      WHERE (lv_result)
      INTO TABLE @ms_sql-t_ref->*
-     UP TO 100 ROWS.
+     UP TO @ms_sql-count ROWS.
 
 
   ENDMETHOD.


### PR DESCRIPTION
This PR introduces a default filter value of 500 rows for the "Rows" selection box in the SE16 Cloud interface. The change is intended to prevent the accidental selection of all records from large tables, which could result in performance issues or slowdowns when handling significant data volumes.